### PR TITLE
Release 1.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 cookbook-rb-intrusion CHANGELOG
 ===============
 
+## 1.2.5
+
+  - nilsver
+    - [df1596e] add check every 24h to clean metadata
+
 ## 1.2.4
 
   - Miguel Alvarez

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 cookbook-rb-intrusion CHANGELOG
 ===============
 
+## 1.2.6
+
+  - Rafael Gomez
+    - [2b05efc] remove outdated metadata cleanup task and flush_cache from chef-client upgrade
+
 ## 1.2.5
 
   - nilsver

--- a/resources/metadata.rb
+++ b/resources/metadata.rb
@@ -5,7 +5,7 @@ maintainer       'Eneo Tecnología S.L.'
 maintainer_email 'git@redborder.com'
 license          'AGPL-3.0'
 description      'Installs/Configures redborder ips'
-version          '1.2.5'
+version          '1.2.6'
 
 depends 'rb-common'
 depends 'snmp'

--- a/resources/metadata.rb
+++ b/resources/metadata.rb
@@ -5,7 +5,7 @@ maintainer       'Eneo Tecnología S.L.'
 maintainer_email 'git@redborder.com'
 license          'AGPL-3.0'
 description      'Installs/Configures redborder ips'
-version          '1.2.4'
+version          '1.2.5'
 
 depends 'rb-common'
 depends 'snmp'

--- a/resources/recipes/prepare_system.rb
+++ b/resources/recipes/prepare_system.rb
@@ -5,12 +5,6 @@
 
 extend RbIps::Helpers
 
-# clean metadata to get packages upgrades, every 24h
-execute 'Clean dnf metadata' do
-  command 'dnf clean metadata && touch /var/cache/dnf/last_makecache'
-  only_if '[ -f /var/cache/dnf/last_makecache ] && [ "$(find /var/cache/dnf/last_makecache -mmin +1440)" ]'
-end
-
 # Stop rb-register
 if File.exist?('/etc/redborder/sensor-installed.txt')
   service 'rb-register' do
@@ -21,7 +15,6 @@ end
 
 # Configure and enable chef-client
 dnf_package 'redborder-chef-client' do
-  flush_cache [:before]
   action :upgrade
 end
 


### PR DESCRIPTION
remove outdated metadata cleanup task and flush_cache from chef-client upgrade by @rgomezborder in #20 