### PR TITLE
map node names to their ip

### DIFF
--- a/resources/libraries/update_hosts_file.rb
+++ b/resources/libraries/update_hosts_file.rb
@@ -34,12 +34,12 @@ module RbIps
       ip_services
     end
 
-    # Gets nodes on the format of <hostname>.node of very manager in the cluster.
-    # Returns the names as an array of strings
+    # Searches for all manager nodes
+    # Returns a hash of each manager's IP address to an array of its corresponding node name
     def fetch_node_names
-      nodes = []
+      nodes = Hash.new { |h, k| h[k] = [] }
       Chef::Search::Query.new.search(:node, 'is_manager:true') do |node|
-        nodes << "#{node.name}.node"
+        nodes[node['ipaddress']] << "#{node.name}.node"
       end
       nodes
     end
@@ -66,12 +66,17 @@ module RbIps
     #   cdomain: The cdomain defined on installation of the manager/cluster
     # Returns the reference of the map with the additional info
     def add_manager_names_info(hosts_info, manager_registration_ip, cdomain)
-      hosts_info[manager_registration_ip] = {}
-      intrusion_node_name = "#{node.name}.node"
-      manager_node_names = fetch_node_names
-      node_names = manager_node_names << intrusion_node_name # append
-      hosts_info[manager_registration_ip]['node_names'] = node_names
+      fetch_manager_nodes.each do |ip, names|
+        hosts_info[ip] ||= {}
+        hosts_info[ip]['node_names'] ||= []
+        hosts_info[ip]['node_names'].concat(names)
+      end
+
+      hosts_info[manager_registration_ip] ||= {}
+      hosts_info[manager_registration_ip]['node_names'] ||= []
+      hosts_info[manager_registration_ip]['node_names'] << "#{node.name}.node"
       hosts_info[manager_registration_ip]['cdomain'] = cdomain
+
       hosts_info
     end
 


### PR DESCRIPTION
this fix now adds the management ip of all the nodes in a cluster to the /etc/hosts
Previously only the node the ips was registered to, was added to /etc/hosts